### PR TITLE
Add persistent storage for uploaded files

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -14,11 +14,11 @@ This document describes how to build and run Quest inside Docker and how to publ
 docker compose build
 ```
 
-The Dockerfile installs the requirements and defaults `QUEST_DB_PATH` to `/data/quest.db`. The `/data` directory is exposed as a volume so the SQLite database survives container restarts.
+The Dockerfile installs the requirements and defaults `QUEST_DB_PATH` to `/data/quest.db`. The `/data` directory is exposed as a volume so the SQLite database and uploaded source files survive container restarts.
 
 ## 3. Persistent storage
 
-The provided `docker-compose.yml` mounts the named volume `quest_data` at `/data`. If you already have a `quest.db`, copy it to a safe place and restore it after the first run:
+The provided `docker-compose.yml` mounts the named volume `quest_data` at `/data`. Besides the SQLite database, uploads are written to `/data/uploads` (configurable with `QUEST_STORAGE_DIR`). If you already have a `quest.db`, copy it to a safe place and restore it after the first run:
 
 ```bash
 docker run --rm -v quest_data:/data -v "$PWD:/backup" alpine \
@@ -57,6 +57,6 @@ The named volume keeps the database intact between deployments.
 
 - Verify the Traefik network exists (`docker network ls`). If not, create it and restart Traefik before launching Quest.
 - Check container logs with `docker compose logs -f quest`.
-- Ensure filesystem permissions allow the container to create `/data/quest.db` on first boot; the named volume handles this automatically.
+- Ensure filesystem permissions allow the container to create `/data/quest.db` and `/data/uploads` on first boot; the named volume handles this automatically.
 
 You can adapt these steps to other orchestration tools (ECS, Nomad, etc.) by reusing the same Docker image and environment variables.

--- a/db.py
+++ b/db.py
@@ -31,7 +31,9 @@ def init_db():
             commission_name TEXT,
             webcast_id TEXT,
             source_questions_json TEXT,
-            transcript_text TEXT
+            transcript_text TEXT,
+            agenda_file_path TEXT,
+            transcript_file_path TEXT
         )"""
     )
 
@@ -97,6 +99,8 @@ def init_db():
     _ensure_column(conn, "questions", "answer_status", "TEXT DEFAULT 'draft'")
     _ensure_column(conn, "meetings", "source_questions_json", "TEXT")
     _ensure_column(conn, "meetings", "transcript_text", "TEXT")
+    _ensure_column(conn, "meetings", "agenda_file_path", "TEXT")
+    _ensure_column(conn, "meetings", "transcript_file_path", "TEXT")
 
     conn.commit()
     conn.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     environment:
       QUEST_DB_PATH: /data/quest.db
+      QUEST_STORAGE_DIR: /data/uploads
     volumes:
       - quest_data:/data
     networks:


### PR DESCRIPTION
## Summary
- store uploaded agenda/transcript files on disk alongside the SQLite database and track their locations in each meeting record
- allow the storage directory to be configured through `QUEST_STORAGE_DIR` and mount it in docker-compose by default
- expand the deployment guide to explain the new persistent upload storage

## Testing
- python -m compileall main.py db.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ad86779508327a1ccc3e2b7a51d90)